### PR TITLE
Support for New Scottish Tax Code SD3

### DIFF
--- a/src/Middlewares/TaxCodeModifier.php
+++ b/src/Middlewares/TaxCodeModifier.php
@@ -15,6 +15,7 @@ use Worksome\UkTaxCodeValidator\Rules\NegativePersonalAllowanceRule;
 use Worksome\UkTaxCodeValidator\Rules\NoTaxesRule;
 use Worksome\UkTaxCodeValidator\Rules\RuleInterface;
 use Worksome\UkTaxCodeValidator\Rules\TemporaryTaxCodeRule;
+use Worksome\UkTaxCodeValidator\Rules\AdvancedScottishRateRule;
 use Worksome\UkTaxCodeValidator\Rules\TopScottishRateRule;
 use Worksome\UkTaxCodeValidator\TaxCode;
 
@@ -35,6 +36,7 @@ class TaxCodeModifier implements ModifierInterface
             new MarriageAllowanceTransferredRule($this),
             new HigherRateRule($this),
             new AdditionalRateRule($this),
+            new AdvancedScottishRateRule($this),
             new TopScottishRateRule($this),
             new NoTaxesRule($this),
         ];

--- a/src/Rules/AdvancedScottishRateRule.php
+++ b/src/Rules/AdvancedScottishRateRule.php
@@ -4,11 +4,11 @@ namespace Worksome\UkTaxCodeValidator\Rules;
 
 use Worksome\UkTaxCodeValidator\TaxCode;
 
-class TopScottishRateRule extends RegexRule
+class AdvancedScottishRateRule extends RegexRule
 {
     public function validate(TaxCode $taxCode): bool
     {
-        // Validate against full tax code, as a D3
+        // Validate against full tax code, as a D2
         // should always have a scottish regime modifier in front.
         return parent::validate(
             new TaxCode($taxCode->getOriginalTaxCode())
@@ -17,11 +17,11 @@ class TopScottishRateRule extends RegexRule
 
     protected function regex(): string
     {
-        return /* @lang RegExp */ '/^SD3/';
+        return /* @lang RegExp */ '/^SD2/';
     }
 
     protected function regexForConsume(): string
     {
-        return /* @lang RegExp */ '/^D3/';
+        return /* @lang RegExp */ '/^D2/';
     }
 }

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -29,6 +29,8 @@ it('has valid tax code', function (string $taxCode) {
     'NT', 'NTX', 'NTM1',
     // Top scottish rates
     'SD2', 'SD2X',
+    // Advanced scottish rates
+    'SD3', 'SD3X',
     // Random tests
     'S 123 3 L',
 ]);

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -28,9 +28,9 @@ it('has valid tax code', function (string $taxCode) {
     // Not taxed
     'NT', 'NTX', 'NTM1',
     // Top scottish rates
-    'SD2', 'SD2X',
-    // Advanced scottish rates
     'SD3', 'SD3X',
+    // Advanced scottish rates
+    'SD2', 'SD2X',
     // Random tests
     'S 123 3 L',
 ]);


### PR DESCRIPTION
## Changes
Renamed TopScottishRateRule to AdvancedScottishRateRule to accurately represent its function regarding the Scottish tax system's rate structure.
Introduced a new TopScottishRateRule that includes logic to recognize and process the "SD3" tax code, following the latest tax guidance.
Updated regular expressions within the new TopScottishRateRule to match the "SD3" pattern.
Added unit tests to ensure the correct identification and handling of the "SD3" tax code.

## Background
The "SD3" tax code represents a critical update in the Scottish tax system, indicating a new top rate for Scottish taxpayers. These updates to the system's tax rule naming and processing logic are necessary to ensure compliance with the Scottish Government's tax rate adjustments for 2024.

For more detailed information on the tax changes for 2024, please see the official document: [Tax Tables B-D 2024](https://assets.publishing.service.gov.uk/media/65cb8afa73806a000cec779e/Tax_Tables_B-D_2024.pdf).

## Testing
Implemented new test cases for the "SD3" tax code.